### PR TITLE
Feat: add debug option for GTM consent logging and script injection

### DIFF
--- a/src/runtime/composables/useCookieConsent.ts
+++ b/src/runtime/composables/useCookieConsent.ts
@@ -77,13 +77,13 @@ export function useCookieConsent() {
 
     if (import.meta.client && Array.isArray(config.scripts)) {
       removeScripts(updated)
-      injectScripts(config.scripts, updated, config.gtmConsentMapping)
+      injectScripts(config.scripts, updated, config.gtmConsentMapping, config?.debug || false)
     }
 
     if (import.meta.client && config.gtmConsentMapping) {
       setTimeout(() => {
         if (config.gtmConsentMapping) {
-          return sendConsentToGTM(updated, config.gtmConsentMapping)
+          return sendConsentToGTM(updated, config.gtmConsentMapping, !!config.debug)
         }
       }, 300) // delay to ensure GTM script has time to load
     }

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -59,7 +59,7 @@ export default defineNuxtPlugin(() => {
       ) as Record<string, boolean>
 
       if (import.meta.client) {
-        injectScripts(config.scripts, acceptedCategories, config.gtmConsentMapping)
+        injectScripts(config.scripts, acceptedCategories, config.gtmConsentMapping, config?.debug || false)
       }
     }
   }

--- a/src/runtime/utils/gtmConsent.ts
+++ b/src/runtime/utils/gtmConsent.ts
@@ -13,7 +13,11 @@ declare global {
     gtag?: GtagFunction
   }
 }
-export function sendConsentToGTM(preferences: Record<string, boolean>, mapping: Record<string, GTMConsentField>) {
+export function sendConsentToGTM(
+  preferences: Record<string, boolean>,
+  mapping: Record<string, GTMConsentField>,
+  debug = false,
+) {
   const gtmScript = document.querySelector('script[src*="googletagmanager.com/gtag/js"]')
   if (!gtmScript || typeof window.gtag !== 'function') return
 
@@ -27,5 +31,8 @@ export function sendConsentToGTM(preferences: Record<string, boolean>, mapping: 
 
   window.gtag('consent', 'update', consent)
 
-  console.log('[DEBUG] Sending GTM consent update:', consent)
+  if (debug) {
+    // only log when explicitly enabled via config.debug
+    console.log('[DEBUG] Sending GTM consent update:', consent)
+  }
 }

--- a/src/runtime/utils/scriptManager.ts
+++ b/src/runtime/utils/scriptManager.ts
@@ -3,7 +3,12 @@ import type { CookieScript } from '../../types/cookies'
 import { emitCookieConsentEvent } from '../composables/cookieConsentEvents'
 import { sendConsentToGTM } from './gtmConsent'
 
-export function injectScripts(scripts: CookieScript[], acceptedCategories: Record<string, boolean>, gtmConsentMapping?: Record<string, GTMConsentField>) {
+export function injectScripts(
+  scripts: CookieScript[],
+  acceptedCategories: Record<string, boolean>,
+  gtmConsentMapping?: Record<string, GTMConsentField>,
+  gtmDebug = false,
+) {
   const injected = new Set<string>()
   const injectedCategories = new Set<string>()
 
@@ -51,7 +56,7 @@ export function injectScripts(scripts: CookieScript[], acceptedCategories: Recor
   if (import.meta.client && gtmConsentMapping) {
     setTimeout(() => {
       if (gtmConsentMapping) {
-        return sendConsentToGTM(acceptedCategories, gtmConsentMapping)
+        return sendConsentToGTM(acceptedCategories, gtmConsentMapping, gtmDebug)
       }
     }, 300)
   }

--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -8,4 +8,6 @@ export interface ModuleOptions {
   expiresInDays?: number
   consentVersion?: string
   gtmConsentMapping?: Record<string, GTMConsentField>
+  // when true, debug logs (like GTM consent payload) are printed to console
+  debug?: boolean
 }


### PR DESCRIPTION
Now it only shows the debug log if debug = true is passed in options.
Closes #7 