### PR TITLE
fix: set plugin mode to client-only for SSR compatibility

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -21,6 +21,9 @@ export default defineNuxtModule<ModuleOptions>({
     }
 
     addImportsDir(resolver.resolve('runtime/composables'))
-    addPlugin(resolver.resolve('runtime/plugin'))
+    addPlugin({
+      src: resolver.resolve('runtime/plugin'),
+      mode: 'client',
+    })
   },
 })


### PR DESCRIPTION
## Problem

When using `nuxt-simple-cookie-consent` with server-side rendered pages, the plugin runs during SSR even though it uses browser-only APIs (`document`, `window`) in its utilities (`scriptManager.js`, `gtmConsent.js`).

This causes SSR errors or requires workarounds like manually patching the plugin mode in `nuxt.config.ts`.

## Solution

Explicitly set `mode: 'client'` when registering the plugin, ensuring it only runs on the client side.